### PR TITLE
agrego packages opencv-python y pillow a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ setuptools==39.1.0
 numpy==1.14.5
 # Para los que tienen una placa Nvidia con CUDA, reemplazar con tensorflow-gpu
 tensorflow
+opencv-python
+pillow


### PR DESCRIPTION
Son necesarios los packages **opencv-python** y **pillow** para que funcione correctamente la aplicación. Instalando Anaconda3 de cero y siguiendo los pasos del README.md esos packages no quedan instalados ni en el virtualenv ni en la librería de packages globales de python. 
Sin esos packages cuando se ejecuta la aplicación tira los siguientes error:
**ModuleNotFoundError: No module named 'cv2'**  si falta **opencv-python**
**AttributeError: module 'scipy.misc' has no attribute 'imread'**  si falta **pillow**

Esto pasa en Debian 9. Quizá en otros OS no hace falta instalarlos explícitamente.
